### PR TITLE
Fix building against mono

### DIFF
--- a/modules/benet/enet_node.cpp
+++ b/modules/benet/enet_node.cpp
@@ -80,8 +80,7 @@ void ENetNode::set_network_peer(const Ref<ENetPacketPeer>& p_network_peer) {
 		//last_send_cache_id=1;
 	}
 
-	ERR_EXPLAIN("Supplied NetworkedNetworkPeer must be connecting or connected.");
-	ERR_FAIL_COND(p_network_peer.is_valid() && p_network_peer->get_connection_status()==NetworkedMultiplayerPeer::CONNECTION_DISCONNECTED);
+	ERR_FAIL_COND_MSG(p_network_peer.is_valid() && p_network_peer->get_connection_status()==NetworkedMultiplayerPeer::CONNECTION_DISCONNECTED, "Supplied NetworkedNetworkPeer must be connecting or connected.");
 
 	network_peer=p_network_peer;
 
@@ -430,7 +429,7 @@ void ENetNode::_bind_methods() {
 	ADD_SIGNAL( MethodInfo("server_packet",PropertyInfo(Variant::INT,"channel"),PropertyInfo(Variant::POOL_BYTE_ARRAY,"packet")));
 	ADD_SIGNAL( MethodInfo("peer_packet",PropertyInfo(Variant::INT,"peer"),PropertyInfo(Variant::INT,"channel"),PropertyInfo(Variant::POOL_BYTE_ARRAY,"packet")));
 
-	ClassDB::bind_method(D_METHOD("set_network_peer","peer:ENetPacketPeer"),&ENetNode::set_network_peer);
+	ClassDB::bind_method(D_METHOD("set_network_peer","peer"),&ENetNode::set_network_peer);
 	ClassDB::bind_method(D_METHOD("_network_peer_connected"),&ENetNode::_network_peer_connected);
 	ClassDB::bind_method(D_METHOD("_network_peer_disconnected"),&ENetNode::_network_peer_disconnected);
 	ClassDB::bind_method(D_METHOD("_connected_to_server"),&ENetNode::_connected_to_server);

--- a/modules/benet/enet_packet_peer.cpp
+++ b/modules/benet/enet_packet_peer.cpp
@@ -451,8 +451,7 @@ Error ENetPacketPeer::put_packet_channel(const uint8_t *p_buffer, int p_buffer_s
 
 		E = peer_map.find(ABS(target_peer));
 		if (!E) {
-			ERR_EXPLAIN("Invalid Target Peer: " + itos(target_peer));
-			ERR_FAIL_V(ERR_INVALID_PARAMETER);
+			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "Invalid Target Peer: " + itos(target_peer));
 		}
 	}
 
@@ -670,7 +669,7 @@ void ENetPacketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_client", "ip", "port", "channels", "in_bandwidth", "out_bandwidth"), &ENetPacketPeer::create_client, DEFVAL(1), DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("close_connection"), &ENetPacketPeer::close_connection);
 	ClassDB::bind_method(D_METHOD("set_compression_mode", "mode"), &ENetPacketPeer::set_compression_mode);
-	ClassDB::bind_method(D_METHOD("put_packet_channel:Error", "pkt:PoolByteArray", "channel:int"), &ENetPacketPeer::_put_packet_channel);
+	ClassDB::bind_method(D_METHOD("put_packet_channel", "pkt", "channel"), &ENetPacketPeer::_put_packet_channel);
 	ClassDB::bind_method(D_METHOD("get_compression_mode"), &ENetPacketPeer::get_compression_mode);
 	ClassDB::bind_method(D_METHOD("set_bind_ip", "ip"), &ENetPacketPeer::set_bind_ip);
 


### PR DESCRIPTION
In Godot 3 there's no need to specify types while binding methods.

I also replaced `ERR_EXPLAIN` macro with new ones since this macro no longer exists.